### PR TITLE
fix(agent-account): add execute-proposal pass-through to complete governance lifecycle

### DIFF
--- a/contracts/agent/agent-account.clar
+++ b/contracts/agent/agent-account.clar
@@ -225,6 +225,32 @@
   )
 )
 
+;; Execute a passed proposal through an approved voting contract
+(define-public (execute-proposal
+    (votingContract <dao-core-proposals-trait>)
+    (proposalId uint)
+    (proposal <dao-proposal-trait>)
+  )
+  (begin
+    (asserts! (use-proposals-allowed) ERR_OPERATION_NOT_ALLOWED)
+    (asserts!
+      (is-approved-contract (contract-of votingContract) APPROVED_CONTRACT_VOTING)
+      ERR_CONTRACT_NOT_APPROVED
+    )
+    (print {
+      notification: "agent-account/execute-proposal",
+      payload: {
+        votingContract: (contract-of votingContract),
+        proposalId: proposalId,
+        proposal: (contract-of proposal),
+        sender: tx-sender,
+        caller: contract-caller
+      }
+    })
+    (as-contract (contract-call? votingContract execute-proposal proposalId proposal))
+  )
+)
+
 ;; ============================================================
 ;; CONFIGURATION (owner or agent with permission)
 ;; ============================================================

--- a/contracts/traits/agent-traits.clar
+++ b/contracts/traits/agent-traits.clar
@@ -54,6 +54,11 @@
     (<dao-core-proposals-trait> uint <dao-proposal-trait>)
     (response bool uint)
   )
+  ;; Execute a passed + concluded proposal through the agent account
+  (execute-proposal
+    (<dao-core-proposals-trait> uint <dao-proposal-trait>)
+    (response bool uint)
+  )
 ))
 
 ;; Agent account configuration interface.

--- a/contracts/traits/dao-traits.clar
+++ b/contracts/traits/dao-traits.clar
@@ -120,6 +120,10 @@
     (uint <proposal>)
     (response bool uint)
   )
+  (execute-proposal
+    (uint <proposal>)
+    (response bool uint)
+  )
   (get-proposal-data
     (uint)
     (response


### PR DESCRIPTION
## Summary

Closes #2

This PR adds the missing `execute-proposal` pass-through to `agent-account.clar`, completing the full DAO governance lifecycle. Without this function, agents can conclude a proposal (mark it as passed) but cannot execute it (actually run the proposal code), breaking the last step of governance.

Changes across three files:

- `contracts/traits/dao-traits.clar`: adds `execute-proposal` to the `core-proposals` trait, between `conclude-proposal` and `get-proposal-data`
- `contracts/traits/agent-traits.clar`: adds `execute-proposal` to the `agent-account-proposals` trait, after `conclude-proposal`
- `contracts/agent/agent-account.clar`: adds the `execute-proposal` public function using the exact same authorization pattern as `conclude-proposal` (checks `use-proposals-allowed` and `is-approved-contract` before delegating to the voting contract via `as-contract`)

## Test plan

- [ ] Verify `agent-account.clar` now implements the `agent-account-proposals` trait without errors
- [ ] Deploy to testnet and confirm the full governance lifecycle: create-proposal -> vote-on-proposal -> conclude-proposal -> execute-proposal
- [ ] Confirm that calling `execute-proposal` without `use-proposals-allowed` returns `ERR_OPERATION_NOT_ALLOWED`
- [ ] Confirm that calling `execute-proposal` with an unapproved voting contract returns `ERR_CONTRACT_NOT_APPROVED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)